### PR TITLE
Move registers-generator submodule to top directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = third-party/verilog-pcie
 	url = ../wd-nvme-verilog-pcie.git
 [submodule "third-party/registers-generator"]
-	path = third-party/registers-generator
+	path = registers-generator
 	url = ../wd-nvme-registers-generator.git

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DOCKER_TAG ?= $(DOCKER_IMAGE_PREFIX)$(DOCKER_TAG_NAME)
 # Input paths -----------------------------------------------------------------
 
 THIRD_PARTY_DIR = $(ROOT_DIR)/third-party
-REGGEN_DIR = $(ROOT_DIR)/third-party/registers-generator
+REGGEN_DIR = $(ROOT_DIR)/registers-generator
 DOCKER_DIR = $(ROOT_DIR)/docker
 VIVADO_COLOR_SCRIPT = $(ROOT_DIR)/vivado/tools/color_log.awk
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ includes the most important files and directories.
 ├── hw.dockerfile
 ├── Makefile
 ├── tests
+├── registers-generator
 ├── third-party
-│   ├── registers-generator
 │   └── verilog-pcie
 └── vivado
     ├── build_project.sh
@@ -71,11 +71,12 @@ includes the most important files and directories.
 * `tests/` - contains test software that can help developing
   the hardware setup for AN300 boards.
 
+* `registers-generator` - contains scripts used to parse the NVMe specification
+   and generate the NVMe registers in chisel.
+
 * `third-party/` - the directory used to store all external projects used as
-  a part of the `Alkali FPGA design`. The `register-generator` directory
-  contains scripts used to parse the NVMe specification and generate
-  the NVMe registers in chisel. The `verilog-pcie`, on the other hand,
-  holds the PCIe IP-cores used in the design for the Basat board.
+  a part of the `Alkali FPGA design`. The `verilog-pcie` directory holds
+  the PCIe IP-cores used in the design for the Basat board.
 
 * `vivado` - contains the main Vivado design. The `build_project.sh` is
   a helper script used to build the Vivado design. The `ip_repo/` subdirectory


### PR DESCRIPTION
This PR moves the registers-generator submodule from third-party to the main directory.
It contains all the required adjustments for that change